### PR TITLE
feat: Add GitHub Action for building Node.js Lambda projects

### DIFF
--- a/node-tools/build-lambda/README.md
+++ b/node-tools/build-lambda/README.md
@@ -7,7 +7,7 @@ This GitHub Action builds a Node.js project, preparing it for deployment, typica
 | Name              | Description                                                                 | Required | Default         |
 |-------------------|-----------------------------------------------------------------------------|----------|-----------------|
 | `project-path`    | Path to the Node.js project directory.                                      | `true`   |                 |
-| `node-version`    | Node.js version to use for building (e.g., '16', '18', '20').                 | `true`   | `'18'`          |
+| `node-version`    | Node.js version to use for building (e.g., '18', '20', '22').                 | `true`   | `'22'`          |
 | `install-command` | Command to install dependencies.                                            | `false`  | `'npm install'` |
 | `build-command`   | Command to build the project.                                               | `false`  | `'npm run build'`|
 
@@ -36,7 +36,7 @@ jobs:
         # Or use: your-org/your-repo/node-tools/build-lambda@main if in another repo
         with:
           project-path: 'src/my-lambda-function' # Path to your lambda source code
-          node-version: '18'
+          node-version: '22'
           # Optional: specify custom install or build commands
           # install-command: 'yarn install --frozen-lockfile'
           # build-command: 'yarn build:prod'

--- a/node-tools/build-lambda/README.md
+++ b/node-tools/build-lambda/README.md
@@ -1,0 +1,78 @@
+# Build Lambda - Node.js Action
+
+This GitHub Action builds a Node.js project, preparing it for deployment, typically to a Lambda-like environment. It sets up a specified Node.js version, installs dependencies, runs a build script, and then copies the build artifacts to a `build-output` directory.
+
+## Inputs
+
+| Name              | Description                                                                 | Required | Default         |
+|-------------------|-----------------------------------------------------------------------------|----------|-----------------|
+| `project-path`    | Path to the Node.js project directory.                                      | `true`   |                 |
+| `node-version`    | Node.js version to use for building (e.g., '16', '18', '20').                 | `true`   | `'18'`          |
+| `install-command` | Command to install dependencies.                                            | `false`  | `'npm install'` |
+| `build-command`   | Command to build the project.                                               | `false`  | `'npm run build'`|
+
+## Outputs
+
+| Name                | Description                                         |
+|---------------------|-----------------------------------------------------|
+| `build-output-path` | Path to the directory containing the build artifacts. This will be `${GITHUB_WORKSPACE}/build-output`. |
+
+## Example Usage
+
+```yaml
+name: Build Node.js Lambda
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build Lambda function
+        uses: ./node-tools/build-lambda # Assumes action is in this repo
+        # Or use: your-org/your-repo/node-tools/build-lambda@main if in another repo
+        with:
+          project-path: 'src/my-lambda-function' # Path to your lambda source code
+          node-version: '18'
+          # Optional: specify custom install or build commands
+          # install-command: 'yarn install --frozen-lockfile'
+          # build-command: 'yarn build:prod'
+
+      - name: Upload artifacts (example)
+        uses: actions/upload-artifact@v3
+        with:
+          name: lambda-build-artifacts
+          path: ${{ steps.build.outputs.build-output-path }} # Use the output from the build step
+          # Note: The actual output path will be something like /home/runner/work/your-repo/your-repo/build-output
+          # You might need to adjust paths based on your runner environment and GITHUB_WORKSPACE
+
+      # Example: Deploy to AWS Lambda (conceptual)
+      # - name: Deploy to AWS Lambda
+      #   uses: aws-actions/aws-lambda-deploy@v1 # This is a hypothetical action
+      #   with:
+      #     function-name: 'my-lambda-function'
+      #     zip-file: ${{ steps.build.outputs.build-output-path }}/artifact.zip # Assuming your build creates a zip
+```
+
+## How it Works
+
+1.  **Setup Node.js**: Uses `actions/setup-node` to install and configure the specified `node-version`.
+2.  **Install Dependencies**: Navigates to the `project-path` and runs the `install-command`.
+3.  **Build Project**: Runs the `build-command` in the `project-path`.
+4.  **Prepare Output**:
+    *   Creates a directory named `build-output` inside the `GITHUB_WORKSPACE`.
+    *   The `entrypoint.sh` script then attempts to copy common build artifact directories (`dist/`, `build/`, `public/`) from the `project-path` into this `build-output` directory.
+    *   If these standard directories are not found, it falls back to copying `package.json`, `package-lock.json` (if available), and `node_modules/` (if available).
+    *   It's recommended that your build process outputs artifacts to a standard location like `dist` or `build` within your `project-path`.
+
+## Customizing Artifact Copying
+
+The `entrypoint.sh` script included in this action has a basic logic for finding and copying build artifacts. If your project has a different structure or you need more specific control over what gets copied, you can:
+
+1.  **Fork this action**: Modify the `entrypoint.sh` script to match your project's needs.
+2.  **Standardize your build output**: Ensure your project's build script outputs all necessary files into a `dist` or `build` directory within your `project-path`.
+
+This action provides a general-purpose way to build Node.js projects. For complex scenarios, further customization of the `entrypoint.sh` script might be necessary.

--- a/node-tools/build-lambda/action.yml
+++ b/node-tools/build-lambda/action.yml
@@ -1,0 +1,77 @@
+name: 'Build Lambda - Node.js'
+description: 'Builds a Node.js project and outputs the artifacts to a build-output directory.'
+inputs:
+  project-path:
+    description: 'Path to the Node.js project'
+    required: true
+  node-version:
+    description: 'Node.js version to use for building'
+    required: true
+    default: '18' # Default to a common LTS version
+  install-command:
+    description: 'Command to install dependencies (e.g., npm install, yarn install)'
+    required: false
+    default: 'npm install'
+  build-command:
+    description: 'Command to build the project (e.g., npm run build, yarn build)'
+    required: false
+    default: 'npm run build'
+  # Considering what artifacts to copy. Often it's a 'dist' or 'build' folder.
+  # For flexibility, let's assume the build command produces artifacts in a known location
+  # and the user's build script is responsible for placing them where they can be found.
+  # The action will then copy the entire project-path (after build) to build-output,
+  # or we can add another input for artifact_path.
+  # For now, let's keep it simple and the script will copy common output folders.
+
+outputs:
+  build-output-path:
+    description: 'Path to the directory containing the build artifacts'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Build Project
+      shell: bash
+      run: |
+        echo "Starting build in ${{ inputs.project-path }} with Node ${{ inputs.node-version }}"
+        cd ${{ inputs.project-path }}
+        echo "Running install command: ${{ inputs.install-command }}"
+        ${{ inputs.install-command }}
+        echo "Running build command: ${{ inputs.build-command }}"
+        ${{ inputs.build-command }}
+
+    # The creation of 'build-output' and copying artifacts will be handled
+    # by the dedicated script (next plan step) for more complex logic if needed.
+    # For now, let's assume the main script (entrypoint.sh) will handle this.
+    - name: Prepare Output Directory
+      shell: bash
+      run: |
+        # The actual script defined in the next step will handle this.
+        # This is a placeholder to show where it fits.
+        # It will create 'build-output' and copy artifacts.
+        # For now, we'll just ensure the script is called.
+        cp $GITHUB_ACTION_PATH/entrypoint.sh .entrypoint.sh
+        chmod +x .entrypoint.sh
+        ./.entrypoint.sh           "${{ inputs.project-path }}"           "${{ inputs.node-version }}"           "${{ inputs.install-command }}"           "${{ inputs.build-command }}"
+      # The output path will be set by the script.
+      # For composite actions, it's a bit tricky to set dynamic output paths directly
+      # from a script step to an action output.
+      # A common pattern is to have the script echo a value and then use that.
+      # Or, the script creates a well-known directory, and that path is outputted.
+      # Let's have the script create 'build-output' inside GITHUB_WORKSPACE
+      # and then output that path.
+
+    - name: Set build output path
+      id: set_output
+      shell: bash
+      run: echo "build-path=${{ github.workspace }}/build-output" >> $GITHUB_OUTPUT
+
+outputs: # Redefining outputs here based on composite action structure
+  build-output-path:
+    description: 'Path to the directory containing the build artifacts.'
+    value: ${{ steps.set_output.outputs.build-path }}

--- a/node-tools/build-lambda/action.yml
+++ b/node-tools/build-lambda/action.yml
@@ -7,7 +7,7 @@ inputs:
   node-version:
     description: 'Node.js version to use for building'
     required: true
-    default: '18' # Default to a common LTS version
+    default: '22'
   install-command:
     description: 'Command to install dependencies (e.g., npm install, yarn install)'
     required: false

--- a/node-tools/build-lambda/entrypoint.sh
+++ b/node-tools/build-lambda/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+PROJECT_PATH="$1"
+# NODE_VERSION="$2" # Already handled by actions/setup-node in action.yml
+# INSTALL_COMMAND="$3" # Already executed in action.yml
+# BUILD_COMMAND="$4" # Already executed in action.yml
+
+echo "--- Entrypoint Script Started ---"
+echo "Project Path: ${PROJECT_PATH}"
+echo "GitHub Workspace: ${GITHUB_WORKSPACE}"
+
+# Define the output directory within the GitHub Workspace
+OUTPUT_DIR="${GITHUB_WORKSPACE}/build-output"
+
+echo "Creating output directory: ${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+
+echo "Changing to project path: ${PROJECT_PATH}"
+cd "${PROJECT_PATH}"
+
+echo "Copying build artifacts to ${OUTPUT_DIR}"
+
+# Common Node.js build output directories and files
+# Add or remove based on common patterns or if a specific artifact_path input is added later
+if [ -d "dist" ]; then
+  echo "Copying dist/ folder..."
+  cp -r dist/* "${OUTPUT_DIR}/"
+elif [ -d "build" ]; then
+  echo "Copying build/ folder..."
+  cp -r build/* "${OUTPUT_DIR}/"
+elif [ -d "public" ]; then # Common for static sites
+  echo "Copying public/ folder..."
+  cp -r public/* "${OUTPUT_DIR}/"
+elif [ -f "package.json" ]; then
+  # Fallback: if specific build folders aren't found,
+  # copy essential files for a lambda function:
+  # package.json, node_modules (if they exist after npm install), and common entry files.
+  # This part might need to be more sophisticated or configurable.
+  echo "Copying package.json, package-lock.json (if exists), and other relevant files..."
+  cp package.json "${OUTPUT_DIR}/"
+  if [ -f "package-lock.json" ]; then
+    cp package-lock.json "${OUTPUT_DIR}/"
+  fi
+  if [ -d "node_modules" ]; then
+    echo "Copying node_modules/ folder..."
+    # Note: Copying node_modules can be large and slow.
+    # Ideally, the lambda deployment package handles dependencies separately.
+    # For a generic build action, providing the modules might be expected.
+    cp -R node_modules "${OUTPUT_DIR}/"
+  fi
+  # Add common main files, e.g., index.js, app.js. User might need to configure this.
+  if [ -f "index.js" ]; then cp index.js "${OUTPUT_DIR}/"; fi
+  if [ -f "app.js" ]; then cp app.js "${OUTPUT_DIR}/"; fi
+  # Add other potential compiled outputs if not in dist/build
+  if [ -d "lib" ]; then cp -r lib/* "${OUTPUT_DIR}/lib/" || true; fi # if lib is output
+  if [ -d "src" ] && [ ! -d "dist" ] && [ ! -d "build" ]; then # if src is used directly (e.g. with ts-node in dev)
+     # Potentially copy src if no other build output is found, though this is less common for 'build'
+     echo "Warning: No standard 'dist' or 'build' folder found, consider copying 'src' if applicable for your runtime."
+  fi
+else
+  echo "Warning: No standard build output (dist, build, public) or package.json found in ${PROJECT_PATH}."
+  echo "Please ensure your build command ('${BUILD_COMMAND}') generates artifacts in a recognized location, or customize this script."
+  # Create a dummy file to ensure the output directory is not empty, preventing potential errors in downstream steps
+  touch "${OUTPUT_DIR}/.empty_placeholder"
+fi
+
+echo "Listing contents of ${OUTPUT_DIR}:"
+ls -la "${OUTPUT_DIR}"
+
+echo "--- Entrypoint Script Finished ---"


### PR DESCRIPTION
This commit introduces a new GitHub Action located in `node-tools/build-lambda`.

The action is designed to:
- Set up a specified version of Node.js.
- Install project dependencies using a configurable install command (defaults to `npm install`).
- Build the project using a configurable build command (defaults to `npm run build`).
- Copy the resulting artifacts (from common directories like `dist/`, `build/`, or `public/`, with a fallback for `package.json` and `node_modules/`) into a `build-output` directory within the `GITHUB_WORKSPACE`.

Inputs:
- `project-path` (required): Path to the Node.js project.
- `node-version` (required, default: '18'): Node.js version.
- `install-command` (optional, default: 'npm install'): Command for installing dependencies.
- `build-command` (optional, default: 'npm run build'): Command for building the project.

Outputs:
- `build-output-path`: Path to the `build-output` directory containing the artifacts.

A `README.md` is included with usage instructions and an example workflow.